### PR TITLE
fix: string format error

### DIFF
--- a/thrift2pyi/convert.py
+++ b/thrift2pyi/convert.py
@@ -106,7 +106,7 @@ class Thrift2pyi(object):
         elif isinstance(v, string_types):
             return "'%s'" % v
         else:
-            raise Thrift2pyiException("%s do not support" % v)
+            raise Thrift2pyiException("%s do not support" % str(v))
 
     def _spec2params(self, default_spec, thrift_spec):
         default_dict = {}


### PR DESCRIPTION
在 _consts2pyi 函数中遍历到 typedef 语法的时候会报错
![CleanShot 2024-06-16 at 19 53 36](https://github.com/nhywieza/thrift2pyi/assets/46246823/1a0e6688-1178-4e6c-9e1c-c90cea7107c7)

在 _2v 函数中 v 的值为 tuple
![CleanShot 2024-06-16 at 19 57 03@2x](https://github.com/nhywieza/thrift2pyi/assets/46246823/a270f2d9-6c57-4792-8bae-18993ae26f6e)

格式化字符串会报错
![CleanShot 2024-06-16 at 20 00 46@2x](https://github.com/nhywieza/thrift2pyi/assets/46246823/8a028ccf-8cde-4025-abc2-7ace9ef3ad8f)

`TypeError: not all arguments converted during string formatting`
所以
`raise Thrift2pyiException("%s do not support" % v)` 应改为 `raise Thrift2pyiException("%s do not support" % str(v))`