### PR TITLE
feat: process_typedef correctly;

### DIFF
--- a/thrift2pyi/convert.py
+++ b/thrift2pyi/convert.py
@@ -105,6 +105,8 @@ class Thrift2pyi(object):
             return str(v)
         elif isinstance(v, string_types):
             return "'%s'" % v
+        elif isinstance(v, tuple):
+            return self._2v(v[1])
         else:
             raise Thrift2pyiException("%s do not support" % v)
 


### PR DESCRIPTION
Support for typedef grammar:

`typedef FooType Foo`

For example:

```thrift
struct FooType {
    1: required i32 id,
}

typedef FooType Foo

struct Bar {
    1: required Foo test2,
}
```

This file will be transform to:
```pyi
# coding:utf-8


# noinspection PyPep8Naming, PyShadowingNames
class FooType(object):
    id: int

    def __init__(self, id: int = None) -> None:
        ...


# noinspection PyPep8Naming, PyShadowingNames
class Bar(object):
    test2: FooType

    def __init__(self, test2: FooType = None) -> None:
        ...
```
